### PR TITLE
disabled non-blocking socket, because its not what you want!

### DIFF
--- a/src/KISSmetrics/Transport/Sockets.php
+++ b/src/KISSmetrics/Transport/Sockets.php
@@ -95,7 +95,7 @@ class Sockets implements Transport {
       throw new TransportException("Cannot connect to the KISSmetrics server: " . $errstr);
     }
 
-    stream_set_blocking($fp, 0);
+    //stream_set_blocking($fp, 0);
 
     $i = 0;
 


### PR DESCRIPTION
Non-blocking sockets are only usefull if you want to have two sockets in one thread. In this case you loose data (cause there is no select() nor multiple fwrites if not all bytes have been sent.
