### PR TITLE
Bugfix delayed transport

### DIFF
--- a/src/KISSmetrics/Transport/Delayed.php
+++ b/src/KISSmetrics/Transport/Delayed.php
@@ -141,7 +141,7 @@ class Delayed extends Sockets implements Transport {
   public function sendLoggedData() {
     // Load all stored queries.
     $data = file_get_contents($this->getLogFile());
-    $data = explode('\n', $data);
+    $data = explode(PHP_EOL, $data);
 
     // Unserialize all the queries into a single array.
     $all_queries = array();

--- a/src/KISSmetrics/Transport/Delayed.php
+++ b/src/KISSmetrics/Transport/Delayed.php
@@ -146,8 +146,10 @@ class Delayed extends Sockets implements Transport {
     // Unserialize all the queries into a single array.
     $all_queries = array();
     foreach ($data as $serialized_queries) {
-      $queries = unserialize($serialized_queries);
-      $all_queries += $queries;
+      if($serialized_queries !== null && strlen($serialized_queries) !== 0) {
+        $queries = unserialize($serialized_queries);
+        $all_queries = array_merge($all_queries, $queries);
+      }
     }
 
     try {


### PR DESCRIPTION
The original code only sent the first recorded event in the log file. I fixed the code so all events are now sent over to KISSmetrics.
I also changed the line separator in a cross platform line separator.