### PR TITLE
Easier includes of the library

### DIFF
--- a/src/KISSmetrics/KM.php
+++ b/src/KISSmetrics/KM.php
@@ -1,0 +1,10 @@
+<?php
+
+// Include dependencies classes for easy include
+require_once( dirname(__FILE__).'/Client.php' );
+require_once( dirname(__FILE__).'/ClientException.php' );
+require_once( dirname(__FILE__).'/Transport/Transport.php' );
+require_once( dirname(__FILE__).'/Transport/TransportException.php' );
+require_once( dirname(__FILE__).'/Transport/Sockets.php' );
+require_once( dirname(__FILE__).'/Transport/Delayed.php' );
+require_once( dirname(__FILE__).'/Transport/Mock.php' );


### PR DESCRIPTION
Previously you would need to include each of the files from this repo
individually in the script(s) that actually use the files. While easy
enough to do, it would be easier to simply include a single base file
and have it perform the required includes for us.

I've added this as a separate file rather than into Client.php to
preserve backwards compatibility. New users can include KM.php while the
folks including the files individually can ignore the new file and carry
on with the old way.