### PR TITLE
Make declaration of Delayed and Sockets are the same

### DIFF
--- a/src/KISSmetrics/Transport/Delayed.php
+++ b/src/KISSmetrics/Transport/Delayed.php
@@ -60,13 +60,26 @@ class Delayed extends Sockets implements Transport {
   /**
    * Create new instance of KISSmeterics\Transport\Delayed with defaults set.
    *
-   * @param string $log_dir
-   *   Full path to local file system directory where event logs are stored.
+   * @param array $params
+   *   $params = [
+   *     'log_dir' => (string) Full path to local file system directory where event logs are stored.
+   *     'host'    => (string) HTTP host to use when connecting to the KISSmetrics API.
+   *     'port'    => (int) HTTP port to use when connecting to the KISSmetrics API.
+   *   ]
    *
    * @return \KISSmetrics\Transport\Delayed
    */
-  public static function initDefault($log_dir) {
-    return new static($log_dir, 'trk.kissmetrics.com', 80);
+  public static function initDefault($params = array()) {
+    if (!array_key_exists('log_dir', $params)) {
+      throw new TransportException("Cannot initialize the instance of KISSmeterics\Transport\Delayed because of missing 'log_dir' param");
+    }
+
+    $default = array(
+      'host' => 'trk.kissmetrics.com',
+      'port' => 80,
+    );
+    $values = array_merge($default, $params);
+    return new static($values['log_dir'], $values['host'], $values['port']);
   }
 
   /**

--- a/src/KISSmetrics/Transport/Sockets.php
+++ b/src/KISSmetrics/Transport/Sockets.php
@@ -63,10 +63,22 @@ class Sockets implements Transport {
 
   /**
    * Create new instance with KISSmetrics API defaults
+   *
+   * @param array $params
+   *   $params = [
+   *     'host'    => (string) HTTP host to use when connecting to the KISSmetrics API.
+   *     'port'    => (int) HTTP port to use when connecting to the KISSmetrics API.
+   *   ]
+   *
    * @return Sockets
    */
-  public static function initDefault() {
-    return new static('trk.kissmetrics.com', 80);
+  public static function initDefault($params = array()) {
+    $default = array(
+      'host' => 'trk.kissmetrics.com',
+      'port' => 80,
+    );
+    $values = array_merge($default, $params);
+    return new static($values['host'], $values['port']);
   }
 
   /**


### PR DESCRIPTION
I cannot use Delayed class because PHP said that Delayed::initDefault() function does not have the same declaration as Sockets::initDefault().
Should I implement like this? Or just need to add `public static function initDefault($log_dir = null)` to Sockets?