### PR TITLE
Fix strict standard in initDefault() functions

### DIFF
--- a/src/KISSmetrics/Transport/Delayed.php
+++ b/src/KISSmetrics/Transport/Delayed.php
@@ -65,7 +65,11 @@ class Delayed extends Sockets implements Transport {
    *
    * @return \KISSmetrics\Transport\Delayed
    */
-  public static function initDefault($log_dir) {
+  public static function initDefault($log_dir=null) {
+    if ($log_dir === null) {
+      throw new TransportException("Cannot initialize the instance of KISSmeterics\Transport\Delayed because of missing 'log_dir' param");
+    }
+
     return new static($log_dir, 'trk.kissmetrics.com', 80);
   }
 

--- a/src/KISSmetrics/Transport/Sockets.php
+++ b/src/KISSmetrics/Transport/Sockets.php
@@ -63,9 +63,13 @@ class Sockets implements Transport {
 
   /**
    * Create new instance with KISSmetrics API defaults
+   *
+   * @param string $log_dir
+   *   This is a fix so that this class has the same declaration as the child class Delayed
+   *
    * @return Sockets
    */
-  public static function initDefault() {
+  public static function initDefault($log_dir=null) {
     return new static('trk.kissmetrics.com', 80);
   }
 


### PR DESCRIPTION
Fix strict standard in initDefault() functions to avoid message:
```
PHP Strict Standards:  Declaration of KISSmetrics\Transport\Delayed::initDefault() should be
compatible with KISSmetrics\Transport\Sockets::initDefault()
```